### PR TITLE
ci: switch from SLSA provenance to actions/attest; update provenance docs

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,10 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  gem-hash:
-    description: "base64-encoded sha256 hashes of distribution files"
-    value: ${{ steps.gem-hash.outputs.gem-hash }}
 
 runs:
   using: composite
@@ -15,12 +11,6 @@ runs:
     - name: Build gemspec
       shell: bash
       run: gem build launchdarkly-server-sdk-ai.gemspec
-
-    - name: Hash gem for provenance
-      id: gem-hash
-      shell: bash
-      run: |
-        echo "gem-hash=$(sha256sum launchdarkly-server-sdk-ai-*.gem | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Publish Library
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,6 @@ on:
         description: 'The tag name to use for the provenance file'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: false
 
   workflow_dispatch:
     inputs:
@@ -22,11 +17,6 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
 jobs:
   build-publish:
@@ -77,19 +67,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['build-publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,6 @@ jobs:
       id-token: write
       contents: write # Needed in this case to write github pages.
       attestations: write
-    outputs:
-      gem-hash: ${{ steps.publish.outputs.gem-hash }}
     steps:
       - uses: actions/checkout@v4
 
@@ -57,15 +55,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Generate checksums file
-        if: ${{ !inputs.dry_run }}
-        env:
-          HASHES: ${{ steps.publish.outputs.gem-hash }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ !inputs.dry_run }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'launchdarkly-server-sdk-ai-*.gem'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,9 @@ jobs:
     permissions:
       id-token: write
       contents: write # Needed in this case to write github pages.
+      attestations: write
     outputs:
-      gem-hash: ${{ steps.publish.outputs.gem-hash}}
+      gem-hash: ${{ steps.publish.outputs.gem-hash }}
     steps:
       - uses: actions/checkout@v4
 
@@ -56,14 +57,13 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-  release-provenance:
-    needs: [ 'build-publish' ]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.build-publish.outputs.gem-hash }}"
-      upload-assets: ${{ !inputs.dry_run }}
-      upload-tag-name: ${{ needs.release-package.outputs.upload-tag-name }}
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.publish.outputs.gem-hash }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
         description: 'The tag name to use for the provenance file'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -17,6 +22,11 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build-publish:
@@ -67,3 +77,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['build-publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,6 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag_name:
-        description: 'The tag name to use for the provenance file'
-        type: string
-        required: true
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'launchdarkly-server-sdk-ai-*.gem'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,12 +58,14 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Generate checksums file
+        if: ${{ !inputs.dry_run }}
         env:
           HASHES: ${{ steps.publish.outputs.gem-hash }}
         run: |
           echo "$HASHES" | base64 -d > checksums.txt
 
       - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,11 +18,53 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
-  
-  release-sdk:
+
+  create-tag:
     needs: release-please
+    if: ${{ needs.release-please.outputs.release-created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag-name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+  release-sdk:
+    needs: ['release-please', 'create-tag']
     if: ${{ needs.release-please.outputs.release-created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag_name: ${{ needs.release-please.outputs.tag-name }}
+
+  publish-release:
+    needs: ['release-please', 'release-sdk']
+    if: ${{ needs.release-please.outputs.release-created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag-name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,52 +19,10 @@ jobs:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
 
-  create-tag:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release-created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag-name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
   release-sdk:
-    needs: ['release-please', 'create-tag']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.release-created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag_name: ${{ needs.release-please.outputs.tag-name }}
-
-  publish-release:
-    needs: ['release-please', 'release-sdk']
-    if: ${{ needs.release-please.outputs.release-created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag-name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,6 @@ jobs:
       pull-requests: write
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
-      tag-name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
@@ -25,4 +24,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
-      tag_name: ${{ needs.release-please.outputs.tag-name }}

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,14 +1,14 @@
-## Verifying SDK build provenance with the SLSA framework
+## Verifying SDK build provenance with GitHub artifact attestations
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
-As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `multiple-provenance.intoto.jsonl`.
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
 
-To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying SDK packages is included below:
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
 
 <!-- x-release-please-start-version -->
 ```
-# Set the version of the SDK to verify
+# Set the version of the library to verify
 VERSION=0.3.0
 ```
 <!-- x-release-please-end -->
@@ -17,27 +17,33 @@ VERSION=0.3.0
 # Download gem
 $ gem fetch launchdarkly-server-sdk-ai -v $VERSION
 
-# Download provenance from Github release
-$ curl --location -O \
-  https://github.com/launchdarkly/ruby-server-sdk-ai/releases/download/${VERSION}/launchdarkly-server-sdk-ai-${VERSION}.gem.intoto.jsonl
-
-# Run slsa-verifier to verify provenance against package artifacts 
-$ slsa-verifier verify-artifact \
---provenance-path launchdarkly-server-sdk-ai-${VERSION}.gem.intoto.jsonl \
---source-uri github.com/launchdarkly/ruby-server-sdk-ai \
-launchdarkly-server-sdk-ai-${VERSION}.gem
+# Verify provenance using the GitHub CLI
+$ gh attestation verify launchdarkly-server-sdk-ai-${VERSION}.gem --owner launchdarkly
 ```
 
 Below is a sample of expected output.
-TODO: Verify these are accurate
+
 ```
-Verified signature against tlog entry index 83653185 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a7df0bbf87a7d5fcaafa551a2101d9f993d251a56a918bb113e81d2c575dc7e25
-Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.10.0" at commit 14c48a68c45871c27409591969e7f4c0ebdcdf62
-Verifying artifact launchdarkly-server-sdk-ai-1.0.0.gem: PASSED
+Loaded digest sha256:... for file://launchdarkly-server-sdk-ai-0.3.0.gem
+Loaded 1 attestation from GitHub API
 
-PASSED: Verified SLSA provenance
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/ruby-server-sdk-ai
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/ruby-server-sdk-ai
+  - Signer workflow: .github/workflows/release-please.yml
 ```
 
-Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
 
-**Note:** These instructions do not apply when building our libraries from source. 
+**Note:** These instructions do not apply when building our libraries from source.  

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with GitHub artifact attestations
+Verifying library build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with the SLSA framework
+Verifying library build provenance with GitHub artifact attestations
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,11 +3,15 @@
     ".": {
       "release-type": "ruby",
       "draft": true,
+      "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
-      "extra-files": ["PROVENANCE.md", "lib/server/ai/version.rb"]
+      "extra-files": [
+        "PROVENANCE.md",
+        "lib/server/ai/version.rb"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "ruby",
-      "draft": true,
       "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "versioning": "default",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "ruby",
-      "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-component-in-tag": false,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "ruby",
+      "draft": true,
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-component-in-tag": false,


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI and documentation-only changes, no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Reference implementation: `launchdarkly/ld-relay` (branch v8).

**Describe the solution you've provided**

GitHub's immutable releases feature prevents modifying a release after it is published. This repo only uses attestation (no binary/artifact uploads to the release), so draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API rather than as release assets, and the release can be published directly by release-please.

Changes across five files:

1. **`release-please-config.json`** — Reformatted `extra-files` array for consistency (no functional changes).

2. **`.github/workflows/release-please.yml`** — Removed dead `tag-name` output. Minor cleanup: whitespace fix and normalized `needs` to array syntax (`needs: ['release-please']`). Removed `tag_name` pass-through to `publish.yml`.

3. **`.github/actions/publish/action.yml`** — Removed the `gem-hash` output and the "Hash gem for provenance" step that base64-encoded sha256 hashes. These are no longer needed since attestation now references the gem file directly on disk.

4. **`.github/workflows/publish.yml`** — Replaced SLSA provenance with `actions/attest@v4` using `subject-path`:
   - Removed the separate `release-provenance` job (which used `slsa-framework/slsa-github-generator` with `upload-assets: true` — incompatible with immutable releases since it uploaded `.intoto.jsonl` as a release asset).
   - Added an inline `Attest build provenance` step in `build-publish` using `subject-path: 'launchdarkly-server-sdk-ai-*.gem'` to reference the gem file directly on disk, eliminating the base64 encode/decode round-trip and checksums file entirely.
   - Added `attestations: write` permission to `build-publish`.
   - Attestation step is gated on `format('{0}', inputs.dry_run) == 'false'` (using `format()` to safely coerce both boolean and string `dry_run` values from `workflow_call` and `workflow_dispatch` triggers).
   - Removed unused `tag_name` input.

5. **`PROVENANCE.md`** — Rewrote to document the new `gh attestation verify` workflow instead of the old `slsa-verifier` approach. Uses `--owner launchdarkly` flag and includes realistic sample output based on the real `gh attestation verify` output format (policy criteria, attestation details).

### Why `subject-path` instead of `subject-checksums`?

An intermediate revision used `subject-checksums` with a base64 decode step to convert the old hash output into a checksums file. This was redundant — the gem file is already on disk in the same job, so `subject-path` can reference it directly via a glob pattern. This eliminates the hash output from the composite action, the base64 decode step, and the checksums file generation entirely.

### Why no draft releases for this repo?

The old SLSA generator uploaded provenance files as release assets via `upload-assets: true`, which would fail under immutable releases. The new `actions/attest@v4` stores attestations in GitHub's attestation API instead — it does not modify the GitHub release at all. Since this repo has no other artifact uploads, release-please can publish directly without a draft→un-draft flow. Repos that upload actual binaries (e.g. ld-relay, cpp-sdks) still use draft releases.

**Describe alternatives you've considered**

- **Draft releases with `publish-release` job**: Unnecessary for this repo since `actions/attest@v4` does not modify the release.
- **`subject-checksums` with base64 round-trip**: Worked but was unnecessarily complex — kept hash outputs in composite actions and added decode + file-write steps in the workflow. `subject-path` is simpler and more direct.
- **`-R launchdarkly/ruby-server-sdk-ai` in PROVENANCE.md**: The verify command could use `-R` (specific repo) instead of `--owner` (org-level). We chose `--owner launchdarkly` for consistency across all SDK repos.

**Additional context**

**Key items for review:**
- [ ] The `subject-path` glob `launchdarkly-server-sdk-ai-*.gem` must match the gem file produced by `gem build` in the composite action. Verify the gem is in the workspace root (not a subdirectory) when the attest step runs.
- [ ] The `format('{0}', inputs.dry_run) == 'false'` condition — ensures attestation is skipped on dry runs regardless of whether `dry_run` arrives as a boolean (`workflow_call`) or string (`workflow_dispatch`).
- [ ] `PROVENANCE.md` sample output is representative (based on real `gh attestation verify` output from ld-relay) but has not been captured from this specific repo. Verify it matches reality after the first attested release.
- [ ] Verify no downstream consumers depend on the old `.intoto.jsonl` provenance file that was previously uploaded as a release asset. Attestations are now stored via GitHub's attestation API instead.
- [ ] The old `release-provenance` job referenced `needs.release-package.outputs.upload-tag-name` for `upload-tag-name`, but the job it depended on was `build-publish` — this was already a latent bug in the original workflow that is now moot with the inline attest step.
- [ ] These workflow changes cannot be fully validated without triggering an actual release. YAML syntax has been validated.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84