### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,37 @@ jobs:
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
+        with:
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          skip-github-release: true
 
   release-sdk:
     needs: ['release-please']


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Follows the pattern established in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622) to support GitHub's immutable releases.

**Describe the solution you've provided**

Splits the single `release-please-action` invocation into two independent passes:

1. **First pass** (`skip-github-pull-request: true`): Attempts to create a GitHub release only. If successful, the workflow checks out the repo and pushes the release tag (with an idempotent guard against existing tags).
2. **Second pass** (`skip-github-release: true`): Runs only if no release was created in pass 1. Handles PR creation/maintenance.

This is required because release-please checks for the existence of a tag when deciding whether to open a new release PR. Without this split, it can create a duplicate release PR immediately after publishing a release because the tag hasn't been pushed yet.

**Describe alternatives you've considered**

A single release-please call (the prior approach) works when releases are mutable, but breaks under GitHub's immutable release model where tag timing matters.

**Additional context**

**Items for reviewer attention:**
- The original action had no `with:` block. Both passes now omit `token:` — release-please-action defaults to `GITHUB_TOKEN`, which should be sufficient given the job's `contents: write` + `pull-requests: write` permissions. Verify this is correct for this repo.
- Tag creation conditions use `release_created` (singular) while the job output exposes `release_created` (also singular, mapped from `steps.release.outputs.release_created`). The downstream `release-sdk` job gates on `needs.release-please.outputs.release-created` — this mapping is unchanged and should continue to work.
- Version comment updated from `# v4` to `# v4.4.0`; the pinned SHA is unchanged.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release workflow by introducing conditional tagging and a second `release-please` invocation; misconfiguration could result in missing tags, duplicate PRs, or blocked releases/publishes.
> 
> **Overview**
> Splits the `release-please` GitHub Actions workflow into two conditional passes: one that creates a GitHub release without opening PRs, and a second that only manages release PRs when no release was created.
> 
> When a release is created, the workflow now checks out the repo and **creates/pushes the release tag** (idempotently skipping if it already exists) before continuing, ensuring tags exist promptly for downstream release logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299847d79a22366a2d3732f7ee385ba0b70b0099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->