### PR TITLE
feat!: Add per-execution runId, at-most-once tracking, and cross-process tracker resumption

### DIFF
--- a/examples/chatbot/aws-bedrock/hello_bedrock.rb
+++ b/examples/chatbot/aws-bedrock/hello_bedrock.rb
@@ -94,7 +94,7 @@ bedrock_client = Aws::BedrockRuntime::Client.new(
 
 # Pass a default for improved resiliency when the flag is unavailable or LaunchDarkly is unreachable; omit for a disabled default.
 # Example:
-#   default = LaunchDarkly::Server::AI::AIConfig.new(
+#   default = LaunchDarkly::Server::AI::AIConfigDefault.new(
 #     enabled: true,
 #     model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'my-model'),
 #     provider: LaunchDarkly::Server::AI::ProviderConfig.new(name: 'my-provider'),

--- a/examples/chatbot/aws-bedrock/hello_bedrock.rb
+++ b/examples/chatbot/aws-bedrock/hello_bedrock.rb
@@ -29,10 +29,13 @@ class BedrockChatbot
     @bedrock_client = bedrock_client
   end
 
+  # Returns [response_content, resumption_token]. The resumption token can be
+  # used to reconstruct a tracker for deferred operations like feedback.
   def ask_agent(question)
     @messages << LaunchDarkly::Server::AI::Message.new('user', question)
+    tracker = @ai_config.create_tracker
     begin
-      response = ai_config.tracker.track_bedrock_converse_metrics do
+      response = tracker.track_bedrock_converse_metrics do
         @bedrock_client.converse(
           map_converse_arguments(
             ai_config.model.name,
@@ -41,15 +44,17 @@ class BedrockChatbot
         )
       end
       @messages << LaunchDarkly::Server::AI::Message.new('assistant', response.output.message.content[0].text)
-      response.output.message.content[0].text
+      [response.output.message.content[0].text, tracker.resumption_token]
     rescue StandardError => e
-      "An error occured: #{e.message}"
+      ["An error occured: #{e.message}", nil]
     end
   end
 
-  def agent_was_helpful(helpful)
+  def agent_was_helpful(helpful, tracker)
+    return if tracker.nil?
+
     kind = helpful ? :positive : :negative
-    ai_config.tracker.track_feedback(kind: kind)
+    tracker.track_feedback(kind: kind)
   end
 
   def map_converse_arguments(model_id, messages)
@@ -105,18 +110,27 @@ end
 
 chatbot = BedrockChatbot.new(ai_config, bedrock_client)
 
+last_resumption_token = nil
+
 loop do
   print "Ask a question (or type 'exit'): "
   question = gets&.chomp
   break if question.nil? || question.strip.downcase == 'exit'
 
-  response = chatbot.ask_agent(question)
+  response, last_resumption_token = chatbot.ask_agent(question)
   puts "AI Response: #{response}"
 end
 
 print "Was the chat helpful? [yes/no]: "
 feedback = gets&.chomp
 
-chatbot.agent_was_helpful(feedback == 'yes') unless feedback.nil?
+unless feedback.nil? || last_resumption_token.nil?
+  tracker = LaunchDarkly::Server::AI::AIConfigTracker.from_resumption_token(
+    token: last_resumption_token,
+    ld_client:,
+    context:
+  )
+  chatbot.agent_was_helpful(feedback == 'yes', tracker)
+end
 
 ld_client.close

--- a/examples/chatbot/openai/hello_openai.rb
+++ b/examples/chatbot/openai/hello_openai.rb
@@ -35,10 +35,13 @@ class Chatbot
     @openai_client = openai_client
   end
 
+  # Returns [response_content, resumption_token]. The resumption token can be
+  # used to reconstruct a tracker for deferred operations like feedback.
   def ask_agent(question)
     @messages << LaunchDarkly::Server::AI::Message.new('user', question)
+    tracker = @ai_config.create_tracker
     begin
-      completion = ai_config.tracker.track_openai_metrics do
+      completion = tracker.track_openai_metrics do
         @openai_client.chat.completions.create(
           model: ai_config.model.name,
           messages: @messages.map(&:to_h)
@@ -46,15 +49,17 @@ class Chatbot
       end
       response_content = completion[:choices][0][:message][:content]
       @messages << LaunchDarkly::Server::AI::Message.new('assistant', response_content)
-      response_content
+      [response_content, tracker.resumption_token]
     rescue StandardError => e
-      "An error occurred: #{e.message}"
+      ["An error occurred: #{e.message}", nil]
     end
   end
 
-  def agent_was_helpful(helpful)
+  def agent_was_helpful(helpful, tracker)
+    return if tracker.nil?
+
     kind = helpful ? :positive : :negative
-    ai_config.tracker.track_feedback(kind: kind)
+    tracker.track_feedback(kind: kind)
   end
 end
 
@@ -94,18 +99,27 @@ end
 
 chatbot = Chatbot.new(ai_config, OpenAI::Client.new(api_key: openai_api_key))
 
+last_resumption_token = nil
+
 loop do
   print "Ask a question (or type 'exit'): "
   question = gets&.chomp
   break if question.nil? || question.strip.downcase == 'exit'
 
-  response = chatbot.ask_agent(question)
+  response, last_resumption_token = chatbot.ask_agent(question)
   puts "AI Response: #{response}"
 end
 
 print "Was the chat helpful? [yes/no]: "
 feedback = gets&.chomp
 
-chatbot.agent_was_helpful(feedback == 'yes') unless feedback.nil?
+unless feedback.nil? || last_resumption_token.nil?
+  tracker = LaunchDarkly::Server::AI::AIConfigTracker.from_resumption_token(
+    token: last_resumption_token,
+    ld_client:,
+    context:
+  )
+  chatbot.agent_was_helpful(feedback == 'yes', tracker)
+end
 
 ld_client.close

--- a/examples/chatbot/openai/hello_openai.rb
+++ b/examples/chatbot/openai/hello_openai.rb
@@ -83,7 +83,7 @@ context = LaunchDarkly::LDContext.create({
 
 # Pass a default for improved resiliency when the flag is unavailable or LaunchDarkly is unreachable; omit for a disabled default.
 # Example:
-#   default = LaunchDarkly::Server::AI::AIConfig.new(
+#   default = LaunchDarkly::Server::AI::AIConfigDefault.new(
 #     enabled: true,
 #     model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'my-model'),
 #     provider: LaunchDarkly::Server::AI::ProviderConfig.new(name: 'my-provider'),

--- a/launchdarkly-server-sdk-ai.gemspec
+++ b/launchdarkly-server-sdk-ai.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.1.0'
 
+  spec.add_dependency 'base64'
   spec.add_dependency 'launchdarkly-server-sdk', '~> 8.5'
   spec.add_dependency 'logger'
   spec.add_dependency 'mustache', '~> 1.1'

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -67,11 +67,6 @@ module LaunchDarkly
           @context = context
           @summary = MetricSummary.new
           @run_id = run_id
-          @tracked_duration = false
-          @tracked_time_to_first_token = false
-          @tracked_tokens = false
-          @tracked_success = nil
-          @tracked_feedback = false
           @logger = LaunchDarkly::Server::AI.default_logger
         end
 
@@ -124,11 +119,10 @@ module LaunchDarkly
         # @param duration [Integer] The duration in milliseconds
         #
         def track_duration(duration)
-          if @tracked_duration
+          unless @summary.duration.nil?
             @logger&.warn("Duration has already been tracked for this execution.")
             return
           end
-          @tracked_duration = true
           @summary.duration = duration
           @ld_client.track(
             '$ld:ai:duration:total',
@@ -158,11 +152,10 @@ module LaunchDarkly
         # @param duration [Integer] The duration in milliseconds
         #
         def track_time_to_first_token(time_to_first_token)
-          if @tracked_time_to_first_token
+          unless @summary.time_to_first_token.nil?
             @logger&.warn("Time to first token has already been tracked for this execution.")
             return
           end
-          @tracked_time_to_first_token = true
           @summary.time_to_first_token = time_to_first_token
           @ld_client.track(
             '$ld:ai:tokens:ttf',
@@ -178,11 +171,10 @@ module LaunchDarkly
         # @param kind [Symbol] The kind of feedback (:positive or :negative)
         #
         def track_feedback(kind:)
-          if @tracked_feedback
+          unless @summary.feedback.nil?
             @logger&.warn("Feedback has already been tracked for this execution.")
             return
           end
-          @tracked_feedback = true
           @summary.feedback = kind
           event_name = kind == :positive ? '$ld:ai:feedback:user:positive' : '$ld:ai:feedback:user:negative'
           @ld_client.track(
@@ -197,11 +189,10 @@ module LaunchDarkly
         # Track a successful AI generation
         #
         def track_success
-          unless @tracked_success.nil?
+          unless @summary.success.nil?
             @logger&.warn("Success or error has already been tracked for this execution.")
             return
           end
-          @tracked_success = true
           @summary.success = true
           @ld_client.track(
             '$ld:ai:generation:success',
@@ -215,11 +206,10 @@ module LaunchDarkly
         # Track an error in AI generation
         #
         def track_error
-          unless @tracked_success.nil?
+          unless @summary.success.nil?
             @logger&.warn("Success or error has already been tracked for this execution.")
             return
           end
-          @tracked_success = false
           @summary.success = false
           @ld_client.track(
             '$ld:ai:generation:error',
@@ -235,11 +225,10 @@ module LaunchDarkly
         # @param token_usage [TokenUsage] An object containing token usage details
         #
         def track_tokens(token_usage)
-          if @tracked_tokens
+          unless @summary.usage.nil?
             @logger&.warn("Tokens have already been tracked for this execution.")
             return
           end
-          @tracked_tokens = true
           @summary.usage = token_usage
           if token_usage.total.positive?
             @ld_client.track(

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'ldclient-rb'
+require 'securerandom'
 
 module LaunchDarkly
   module Server
@@ -64,6 +65,13 @@ module LaunchDarkly
           @provider_name = provider_name
           @context = context
           @summary = MetricSummary.new
+          @run_id = SecureRandom.uuid
+          @tracked_duration = false
+          @tracked_time_to_first_token = false
+          @tracked_tokens = false
+          @tracked_success = nil
+          @tracked_feedback = false
+          @logger = LaunchDarkly::Server::AI.default_logger
         end
 
         #
@@ -72,6 +80,11 @@ module LaunchDarkly
         # @param duration [Integer] The duration in milliseconds
         #
         def track_duration(duration)
+          if @tracked_duration
+            @logger&.warn("Duration has already been tracked for this execution.")
+            return
+          end
+          @tracked_duration = true
           @summary.duration = duration
           @ld_client.track(
             '$ld:ai:duration:total',
@@ -101,6 +114,11 @@ module LaunchDarkly
         # @param duration [Integer] The duration in milliseconds
         #
         def track_time_to_first_token(time_to_first_token)
+          if @tracked_time_to_first_token
+            @logger&.warn("Time to first token has already been tracked for this execution.")
+            return
+          end
+          @tracked_time_to_first_token = true
           @summary.time_to_first_token = time_to_first_token
           @ld_client.track(
             '$ld:ai:tokens:ttf',
@@ -116,6 +134,11 @@ module LaunchDarkly
         # @param kind [Symbol] The kind of feedback (:positive or :negative)
         #
         def track_feedback(kind:)
+          if @tracked_feedback
+            @logger&.warn("Feedback has already been tracked for this execution.")
+            return
+          end
+          @tracked_feedback = true
           @summary.feedback = kind
           event_name = kind == :positive ? '$ld:ai:feedback:user:positive' : '$ld:ai:feedback:user:negative'
           @ld_client.track(
@@ -130,6 +153,11 @@ module LaunchDarkly
         # Track a successful AI generation
         #
         def track_success
+          unless @tracked_success.nil?
+            @logger&.warn("Success or error has already been tracked for this execution.")
+            return
+          end
+          @tracked_success = true
           @summary.success = true
           @ld_client.track(
             '$ld:ai:generation:success',
@@ -143,6 +171,11 @@ module LaunchDarkly
         # Track an error in AI generation
         #
         def track_error
+          unless @tracked_success.nil?
+            @logger&.warn("Success or error has already been tracked for this execution.")
+            return
+          end
+          @tracked_success = false
           @summary.success = false
           @ld_client.track(
             '$ld:ai:generation:error',
@@ -158,6 +191,11 @@ module LaunchDarkly
         # @param token_usage [TokenUsage] An object containing token usage details
         #
         def track_tokens(token_usage)
+          if @tracked_tokens
+            @logger&.warn("Tokens have already been tracked for this execution.")
+            return
+          end
+          @tracked_tokens = true
           @summary.usage = token_usage
           if token_usage.total.positive?
             @ld_client.track(
@@ -223,6 +261,7 @@ module LaunchDarkly
 
         private def flag_data
           {
+            runId: @run_id,
             variationKey: @variation_key,
             configKey: @config_key,
             version: @version,

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -57,7 +57,7 @@ module LaunchDarkly
         # @param provider_name [String] The name of the AI provider
         # @param context [LDContext] The context used for the flag evaluation
         #
-        def initialize(ld_client:, variation_key:, config_key:, version:, model_name:, provider_name:, context:, run_id:)
+        def initialize(ld_client:, run_id:, config_key:, variation_key:, version:, model_name:, provider_name:, context:)
           @ld_client = ld_client
           @variation_key = variation_key
           @config_key = config_key

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -162,7 +162,8 @@ module LaunchDarkly
         #
         def track_time_to_first_token(time_to_first_token)
           unless @summary.time_to_first_token.nil?
-            @logger&.warn("Skipping track_time_to_first_token: time-to-first-token already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
+            @logger&.warn("Skipping track_time_to_first_token: time-to-first-token already recorded on this tracker. " \
+                          "Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.time_to_first_token = time_to_first_token

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -57,7 +57,7 @@ module LaunchDarkly
         # @param provider_name [String] The name of the AI provider
         # @param context [LDContext] The context used for the flag evaluation
         #
-        def initialize(ld_client:, run_id:, config_key:, variation_key:, version:, model_name:, provider_name:, context:)
+        def initialize(ld_client:, run_id:, config_key:, variation_key:, version:, context:, model_name:, provider_name:)
           @ld_client = ld_client
           @variation_key = variation_key
           @config_key = config_key
@@ -80,12 +80,9 @@ module LaunchDarkly
         # @return [String] the resumption token
         #
         def resumption_token
-          payload = {
-            runId: @run_id,
-            configKey: @config_key,
-            variationKey: @variation_key,
-            version: @version,
-          }
+          payload = { runId: @run_id, configKey: @config_key }
+          payload[:variationKey] = @variation_key if @variation_key && !@variation_key.empty?
+          payload[:version] = @version
           Base64.urlsafe_encode64(JSON.generate(payload), padding: false)
         end
 
@@ -105,11 +102,11 @@ module LaunchDarkly
             ld_client: ld_client,
             run_id: payload['runId'],
             config_key: payload['configKey'],
-            variation_key: payload.fetch('variationKey', ''),
+            variation_key: payload.fetch('variationKey', nil),
             version: payload['version'],
+            context: context,
             model_name: '',
-            provider_name: '',
-            context: context
+            provider_name: ''
           )
         end
 

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -290,14 +290,15 @@ module LaunchDarkly
         end
 
         private def flag_data
-          {
+          data = {
             runId: @run_id,
-            variationKey: @variation_key,
             configKey: @config_key,
             version: @version,
             modelName: @model_name,
             providerName: @provider_name,
           }
+          data[:variationKey] = @variation_key if @variation_key && !@variation_key.empty?
+          data
         end
 
         private def openai_to_token_usage(usage)

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -3,7 +3,6 @@
 require 'base64'
 require 'json'
 require 'ldclient-rb'
-require 'securerandom'
 
 module LaunchDarkly
   module Server

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -283,9 +283,9 @@ module LaunchDarkly
         # If the provided block raises, this method will also raise.
         # A failed operation will not have any token usage data.
         #
-        # Because each inner metric is at-most-once per Tracker, calling this
-        # twice on the same Tracker will run the inner block again but produce
-        # no additional metric events.
+        # Subsequent calls re-run the inner block but emit only metrics not
+        # already recorded on this Tracker. Call create_tracker on the AI
+        # Config to start a new run.
         #
         # @yield The block to track.
         # @return The result of the tracked block.
@@ -304,9 +304,9 @@ module LaunchDarkly
         # Track AWS Bedrock conversation operations.
         # This method tracks the duration, token usage, and success/error status.
         #
-        # Because each inner metric is at-most-once per Tracker, calling this
-        # twice on the same Tracker will run the inner block again but produce
-        # no additional metric events.
+        # Subsequent calls re-run the inner block but emit only metrics not
+        # already recorded on this Tracker. Call create_tracker on the AI
+        # Config to start a new run.
         #
         # @yield The block to track.
         # @return [Hash] The original response hash.

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -48,8 +48,7 @@ module LaunchDarkly
       # correlate them in metrics views. See individual track methods for their
       # specific semantics. Call create_tracker on the AI Config to start a new
       # run. A resumption token preserves the runId, so events emitted by a
-      # tracker reconstructed in another process correlate with the original
-      # run.
+      # tracker reconstructed in another process share the original runId.
       #
       class AIConfigTracker
         attr_reader :ld_client, :config_key, :context, :variation_key, :version, :summary, :model_name, :provider_name

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -117,7 +117,7 @@ module LaunchDarkly
         #
         def track_duration(duration)
           unless @summary.duration.nil?
-            @logger&.warn("Duration has already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_duration: duration already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.duration = duration
@@ -150,7 +150,7 @@ module LaunchDarkly
         #
         def track_time_to_first_token(time_to_first_token)
           unless @summary.time_to_first_token.nil?
-            @logger&.warn("Time to first token has already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_time_to_first_token: time-to-first-token already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.time_to_first_token = time_to_first_token
@@ -169,7 +169,7 @@ module LaunchDarkly
         #
         def track_feedback(kind:)
           unless @summary.feedback.nil?
-            @logger&.warn("Feedback has already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_feedback: feedback already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.feedback = kind
@@ -187,7 +187,7 @@ module LaunchDarkly
         #
         def track_success
           unless @summary.success.nil?
-            @logger&.warn("Success or error has already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_success: success/error already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.success = true
@@ -204,7 +204,7 @@ module LaunchDarkly
         #
         def track_error
           unless @summary.success.nil?
-            @logger&.warn("Success or error has already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_error: success/error already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.success = false
@@ -223,7 +223,7 @@ module LaunchDarkly
         #
         def track_tokens(token_usage)
           unless @summary.usage.nil?
-            @logger&.warn("Tokens have already been tracked for this execution. #{flag_data}")
+            @logger&.warn("Skipping track_tokens: token usage already recorded on this tracker. Call create_tracker on the AI Config for a new run. #{flag_data}")
             return
           end
           @summary.usage = token_usage

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'base64'
+require 'json'
 require 'ldclient-rb'
 require 'securerandom'
 
@@ -56,7 +58,7 @@ module LaunchDarkly
         # @param provider_name [String] The name of the AI provider
         # @param context [LDContext] The context used for the flag evaluation
         #
-        def initialize(ld_client:, variation_key:, config_key:, version:, model_name:, provider_name:, context:)
+        def initialize(ld_client:, variation_key:, config_key:, version:, model_name:, provider_name:, context:, run_id:)
           @ld_client = ld_client
           @variation_key = variation_key
           @config_key = config_key
@@ -65,13 +67,56 @@ module LaunchDarkly
           @provider_name = provider_name
           @context = context
           @summary = MetricSummary.new
-          @run_id = SecureRandom.uuid
+          @run_id = run_id
           @tracked_duration = false
           @tracked_time_to_first_token = false
           @tracked_tokens = false
           @tracked_success = nil
           @tracked_feedback = false
           @logger = LaunchDarkly::Server::AI.default_logger
+        end
+
+        #
+        # Returns a URL-safe Base64-encoded JSON token that can be used to reconstruct
+        # a tracker in a different process (e.g. for deferred feedback).
+        #
+        # The token contains: runId, configKey, variationKey, version.
+        # modelName and providerName are NOT included.
+        #
+        # @return [String] the resumption token
+        #
+        def resumption_token
+          payload = {
+            runId: @run_id,
+            configKey: @config_key,
+            variationKey: @variation_key,
+            version: @version,
+          }
+          Base64.urlsafe_encode64(JSON.generate(payload), padding: false)
+        end
+
+        #
+        # Reconstructs a tracker from a resumption token.
+        #
+        # @param token [String] A URL-safe Base64-encoded JSON resumption token
+        # @param ld_client [LDClient] The LaunchDarkly client instance
+        # @param context [LDContext] The context for track events
+        # @return [AIConfigTracker] A new tracker instance
+        #
+        def self.from_resumption_token(token:, ld_client:, context:)
+          json = Base64.urlsafe_decode64(token)
+          payload = JSON.parse(json)
+
+          new(
+            ld_client: ld_client,
+            run_id: payload['runId'],
+            config_key: payload['configKey'],
+            variation_key: payload.fetch('variationKey', ''),
+            version: payload['version'],
+            model_name: '',
+            provider_name: '',
+            context: context
+          )
         end
 
         #

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -41,7 +41,15 @@ module LaunchDarkly
       end
 
       #
-      # The AIConfigTracker class is used to track AI configuration usage.
+      # The AIConfigTracker records metrics for a single AI run. Unless
+      # otherwise noted, the tracker's methods are not safe for concurrent use.
+      #
+      # All events a tracker emits share a runId (a UUIDv4) so LaunchDarkly can
+      # correlate them in metrics views. See individual track methods for their
+      # specific semantics. Call create_tracker on the AI Config to start a new
+      # run. A resumption token preserves the runId, so events emitted by a
+      # tracker reconstructed in another process correlate with the original
+      # run.
       #
       class AIConfigTracker
         attr_reader :ld_client, :config_key, :context, :variation_key, :version, :summary, :model_name, :provider_name
@@ -111,7 +119,9 @@ module LaunchDarkly
         end
 
         #
-        # Track the duration of an AI operation
+        # Track the duration of an AI run.
+        #
+        # Records at most once per Tracker; further calls are ignored.
         #
         # @param duration [Integer] The duration in milliseconds
         #
@@ -144,7 +154,9 @@ module LaunchDarkly
         end
 
         #
-        # Track time to first token
+        # Track time to first token.
+        #
+        # Records at most once per Tracker; further calls are ignored.
         #
         # @param duration [Integer] The duration in milliseconds
         #
@@ -163,7 +175,9 @@ module LaunchDarkly
         end
 
         #
-        # Track user feedback
+        # Track user feedback.
+        #
+        # Records at most once per Tracker; further calls are ignored.
         #
         # @param kind [Symbol] The kind of feedback (:positive or :negative)
         #
@@ -183,7 +197,11 @@ module LaunchDarkly
         end
 
         #
-        # Track a successful AI generation
+        # Track a successful AI generation.
+        #
+        # Records at most once per Tracker. track_success and track_error share
+        # state; only one of the two can record per Tracker, and subsequent
+        # calls are ignored.
         #
         def track_success
           unless @summary.success.nil?
@@ -200,7 +218,11 @@ module LaunchDarkly
         end
 
         #
-        # Track an error in AI generation
+        # Track an error in AI generation.
+        #
+        # Records at most once per Tracker. track_success and track_error share
+        # state; only one of the two can record per Tracker, and subsequent
+        # calls are ignored.
         #
         def track_error
           unless @summary.success.nil?
@@ -217,7 +239,9 @@ module LaunchDarkly
         end
 
         #
-        # Track token usage
+        # Track token usage.
+        #
+        # Records at most once per Tracker; further calls are ignored.
         #
         # @param token_usage [TokenUsage] An object containing token usage details
         #
@@ -259,6 +283,10 @@ module LaunchDarkly
         # If the provided block raises, this method will also raise.
         # A failed operation will not have any token usage data.
         #
+        # Because each inner metric is at-most-once per Tracker, calling this
+        # twice on the same Tracker will run the inner block again but produce
+        # no additional metric events.
+        #
         # @yield The block to track.
         # @return The result of the tracked block.
         #
@@ -275,6 +303,10 @@ module LaunchDarkly
         #
         # Track AWS Bedrock conversation operations.
         # This method tracks the duration, token usage, and success/error status.
+        #
+        # Because each inner metric is at-most-once per Tracker, calling this
+        # twice on the same Tracker will run the inner block again but produce
+        # no additional metric events.
         #
         # @yield The block to track.
         # @return [Hash] The original response hash.

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -109,7 +109,7 @@ module LaunchDarkly
             ld_client: ld_client,
             run_id: payload['runId'],
             config_key: payload['configKey'],
-            variation_key: payload.fetch('variationKey', nil),
+            variation_key: payload.fetch('variationKey', ''),
             version: payload['version'],
             context: context,
             model_name: '',

--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -117,7 +117,7 @@ module LaunchDarkly
         #
         def track_duration(duration)
           unless @summary.duration.nil?
-            @logger&.warn("Duration has already been tracked for this execution.")
+            @logger&.warn("Duration has already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.duration = duration
@@ -150,7 +150,7 @@ module LaunchDarkly
         #
         def track_time_to_first_token(time_to_first_token)
           unless @summary.time_to_first_token.nil?
-            @logger&.warn("Time to first token has already been tracked for this execution.")
+            @logger&.warn("Time to first token has already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.time_to_first_token = time_to_first_token
@@ -169,7 +169,7 @@ module LaunchDarkly
         #
         def track_feedback(kind:)
           unless @summary.feedback.nil?
-            @logger&.warn("Feedback has already been tracked for this execution.")
+            @logger&.warn("Feedback has already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.feedback = kind
@@ -187,7 +187,7 @@ module LaunchDarkly
         #
         def track_success
           unless @summary.success.nil?
-            @logger&.warn("Success or error has already been tracked for this execution.")
+            @logger&.warn("Success or error has already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.success = true
@@ -204,7 +204,7 @@ module LaunchDarkly
         #
         def track_error
           unless @summary.success.nil?
-            @logger&.warn("Success or error has already been tracked for this execution.")
+            @logger&.warn("Success or error has already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.success = false
@@ -223,7 +223,7 @@ module LaunchDarkly
         #
         def track_tokens(token_usage)
           unless @summary.usage.nil?
-            @logger&.warn("Tokens have already been tracked for this execution.")
+            @logger&.warn("Tokens have already been tracked for this execution. #{flag_data}")
             return
           end
           @summary.usage = token_usage

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -178,9 +178,6 @@ module LaunchDarkly
       TRACK_SDK_INFO = '$ld:ai:sdk:info'
       TRACK_USAGE_COMPLETION_CONFIG = '$ld:ai:usage:completion-config'
 
-      # Internal fallback used when no default config is provided. Not part of the public API.
-      DISABLED_AI_CONFIG_DEFAULT = { _ldMeta: { enabled: false } }.freeze
-
       INIT_TRACK_CONTEXT = LaunchDarkly::LDContext.create({
         kind: 'ld_ai',
         key: 'ld-internal-tracking',
@@ -220,7 +217,7 @@ module LaunchDarkly
         def completion_config(key:, context:, default: nil, variables: nil)
           @ld_client.track(TRACK_USAGE_COMPLETION_CONFIG, context, key, 1)
 
-          _completion_config(key:, context:, default: default || DISABLED_AI_CONFIG_DEFAULT, variables:)
+          _completion_config(key:, context:, default: default || AIConfigDefault.disabled, variables:)
         end
 
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -110,6 +110,10 @@ module LaunchDarkly
       class AIConfigDefault
         attr_reader :enabled, :messages, :model, :provider
 
+        def self.disabled
+          new(enabled: false)
+        end
+
         def initialize(enabled: false, model: nil, messages: nil, provider: nil)
           @enabled = enabled
           @messages = messages

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -2,6 +2,7 @@
 
 require 'ldclient-rb'
 require 'mustache'
+require 'securerandom'
 require_relative 'ai_config_tracker'
 require_relative 'sdk_info'
 
@@ -103,14 +104,24 @@ module LaunchDarkly
       # The AIConfig class represents an AI configuration.
       #
       class AIConfig
-        attr_reader :enabled, :messages, :tracker, :model, :provider
+        attr_reader :enabled, :messages, :model, :provider
 
-        def initialize(enabled: nil, model: nil, messages: nil, tracker: nil, provider: nil)
+        def initialize(enabled: nil, model: nil, messages: nil, tracker_factory: nil, provider: nil)
           @enabled = enabled
           @messages = messages
-          @tracker = tracker
+          @tracker_factory = tracker_factory
           @model = model
           @provider = provider
+        end
+
+        #
+        # Creates a new tracker with a fresh runId for tracking a single AI execution.
+        # Returns nil when the config has no tracker factory (e.g. a static disabled config).
+        #
+        # @return [AIConfigTracker, nil] a new tracker instance, or nil
+        #
+        def create_tracker
+          @tracker_factory&.call
         end
 
         #
@@ -182,6 +193,18 @@ module LaunchDarkly
           _completion_config(key:, context:, default: default || AIConfig.disabled, variables:)
         end
 
+        #
+        # Reconstructs a tracker from a resumption token, allowing deferred tracking
+        # (e.g. feedback from a different process).
+        #
+        # @param token [String] A resumption token obtained from AIConfigTracker#resumption_token
+        # @param context [LDContext] The context for track events
+        # @return [AIConfigTracker] A new tracker instance
+        #
+        def create_tracker(token:, context:)
+          AIConfigTracker.from_resumption_token(token: token, ld_client: @ld_client, context: context)
+        end
+
         # @deprecated Use {#completion_config} instead.
         def config(key:, context:, default: nil, variables: nil)
           warn '[DEPRECATION] `config` is deprecated. Use `completion_config` instead.'
@@ -226,20 +249,28 @@ module LaunchDarkly
             )
           end
 
-          tracker = LaunchDarkly::Server::AI::AIConfigTracker.new(
-            ld_client: @ld_client,
-            variation_key: variation.dig(:_ldMeta, :variationKey) || '',
-            config_key: key,
-            version: variation.dig(:_ldMeta, :version) || 1,
-            model_name: model&.name || '',
-            provider_name: provider_config&.name || '',
-            context:
-          )
+          variation_key = variation.dig(:_ldMeta, :variationKey) || ''
+          version = variation.dig(:_ldMeta, :version) || 1
+          model_name = model&.name || ''
+          provider_name = provider_config&.name || ''
+
+          tracker_factory = lambda {
+            LaunchDarkly::Server::AI::AIConfigTracker.new(
+              ld_client: @ld_client,
+              run_id: SecureRandom.uuid,
+              variation_key: variation_key,
+              config_key: key,
+              version: version,
+              model_name: model_name,
+              provider_name: provider_name,
+              context: context
+            )
+          }
 
           AIConfig.new(
             enabled: variation.dig(:_ldMeta, :enabled) || false,
             messages:,
-            tracker:,
+            tracker_factory:,
             model:,
             provider: provider_config
           )

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -140,15 +140,10 @@ module LaunchDarkly
       # a {#create_tracker} factory. Do not instantiate directly — use
       # {AIConfigDefault} for fallback values.
       #
-      class AIConfig
-        attr_reader :enabled, :messages, :model, :provider
-
+      class AIConfig < AIConfigDefault
         def initialize(tracker_factory:, enabled: nil, model: nil, messages: nil, provider: nil)
-          @enabled = enabled
-          @messages = messages
+          super(enabled: enabled, model: model, messages: messages, provider: provider)
           @tracker_factory = tracker_factory
-          @model = model
-          @provider = provider
         end
 
         #
@@ -158,17 +153,6 @@ module LaunchDarkly
         #
         def create_tracker
           @tracker_factory.call
-        end
-
-        def to_h
-          {
-            _ldMeta: {
-              enabled: @enabled || false,
-            },
-            messages: @messages.is_a?(Array) ? @messages.map { |msg| msg&.to_h } : nil,
-            model: @model&.to_h,
-            provider: @provider&.to_h,
-          }
         end
       end
 

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -147,7 +147,10 @@ module LaunchDarkly
         end
 
         #
-        # Creates a new tracker with a fresh runId for tracking a single AI execution.
+        # Creates a new tracker for a fresh AI run. Each call mints a new
+        # runId (a UUIDv4) that LaunchDarkly uses to correlate the run's
+        # events in metrics views. Call this once per AI run; metrics from
+        # different runIds cannot be combined.
         #
         # @return [AIConfigTracker] a new tracker instance
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -143,7 +143,7 @@ module LaunchDarkly
       class AIConfig
         attr_reader :enabled, :messages, :model, :provider
 
-        def initialize(enabled: nil, model: nil, messages: nil, tracker_factory:, provider: nil)
+        def initialize(tracker_factory:, enabled: nil, model: nil, messages: nil, provider: nil)
           @enabled = enabled
           @messages = messages
           @tracker_factory = tracker_factory

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -101,12 +101,45 @@ module LaunchDarkly
       end
 
       #
-      # The AIConfig class represents an AI configuration.
+      # The AIConfigDefault class represents a user-provided fallback AI configuration.
+      #
+      # Pass an instance of this class as the +default:+ parameter to
+      # {Client#completion_config} to control the fallback values when a flag
+      # is not found or cannot be evaluated.
+      #
+      class AIConfigDefault
+        attr_reader :enabled, :messages, :model, :provider
+
+        def initialize(enabled: false, model: nil, messages: nil, provider: nil)
+          @enabled = enabled
+          @messages = messages
+          @model = model
+          @provider = provider
+        end
+
+        def to_h
+          {
+            _ldMeta: {
+              enabled: @enabled || false,
+            },
+            messages: @messages.is_a?(Array) ? @messages.map { |msg| msg&.to_h } : nil,
+            model: @model&.to_h,
+            provider: @provider&.to_h,
+          }
+        end
+      end
+
+      #
+      # The AIConfig class represents an AI configuration returned by the SDK.
+      #
+      # Instances are created by {Client#completion_config} and always include
+      # a {#create_tracker} factory. Do not instantiate directly — use
+      # {AIConfigDefault} for fallback values.
       #
       class AIConfig
         attr_reader :enabled, :messages, :model, :provider
 
-        def initialize(enabled: nil, model: nil, messages: nil, tracker_factory: nil, provider: nil)
+        def initialize(enabled: nil, model: nil, messages: nil, tracker_factory:, provider: nil)
           @enabled = enabled
           @messages = messages
           @tracker_factory = tracker_factory
@@ -176,7 +209,7 @@ module LaunchDarkly
         #
         # @param key [String] The key of the configuration flag
         # @param context [LDContext] The context used when evaluating the flag
-        # @param default [AIConfig] The default value to use if the flag is not found
+        # @param default [AIConfigDefault] The default value to use if the flag is not found
         # @param variables [Hash] Optional variables for rendering messages
         # @return [AIConfig] An AIConfig instance containing the configuration data
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -148,7 +148,7 @@ module LaunchDarkly
 
         #
         # Creates a new tracker for a fresh AI run. Each call mints a new
-        # runId (a UUIDv4) that LaunchDarkly uses to correlate the run's
+        # runId (a UUIDv4) that LaunchDarkly uses to correlate the tracker's
         # events in metrics views. Call this once per AI run; metrics from
         # different runIds cannot be combined.
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -101,15 +101,26 @@ module LaunchDarkly
       end
 
       #
-      # The AIConfigDefault class represents a user-provided fallback AI configuration.
+      # The AIConfigDefault class represents a user-provided fallback AI
+      # configuration.
       #
       # Pass an instance of this class as the +default:+ parameter to
       # {Client#completion_config} to control the fallback values when a flag
       # is not found or cannot be evaluated.
       #
+      # This is an input-only type: it is what an application supplies to the
+      # SDK, never what the SDK returns. The SDK always returns an
+      # {AIConfig}, which carries a tracker factory; AIConfigDefault does not.
+      #
       class AIConfigDefault
         attr_reader :enabled, :messages, :model, :provider
 
+        #
+        # Returns a new AIConfigDefault with enabled: false and no model,
+        # messages, or provider.
+        #
+        # @return [AIConfigDefault] a new disabled fallback config
+        #
         def self.disabled
           new(enabled: false)
         end
@@ -136,14 +147,30 @@ module LaunchDarkly
       #
       # The AIConfig class represents an AI configuration returned by the SDK.
       #
-      # Instances are created by {Client#completion_config} and always include
-      # a {#create_tracker} factory. Do not instantiate directly — use
-      # {AIConfigDefault} for fallback values.
+      # Instances are created by {Client#completion_config} and always carry a
+      # tracker factory; see {#create_tracker}. Do not instantiate directly.
+      # For application-supplied fallback values, use {AIConfigDefault}.
       #
-      class AIConfig < AIConfigDefault
+      class AIConfig
+        attr_reader :enabled, :messages, :model, :provider
+
         def initialize(tracker_factory:, enabled: nil, model: nil, messages: nil, provider: nil)
-          super(enabled: enabled, model: model, messages: messages, provider: provider)
+          @enabled = enabled
+          @messages = messages
+          @model = model
+          @provider = provider
           @tracker_factory = tracker_factory
+        end
+
+        def to_h
+          {
+            _ldMeta: {
+              enabled: @enabled || false,
+            },
+            messages: @messages.is_a?(Array) ? @messages.map { |msg| msg&.to_h } : nil,
+            model: @model&.to_h,
+            provider: @provider&.to_h,
+          }
         end
 
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -116,12 +116,11 @@ module LaunchDarkly
 
         #
         # Creates a new tracker with a fresh runId for tracking a single AI execution.
-        # Returns nil when the config has no tracker factory (e.g. a static disabled config).
         #
-        # @return [AIConfigTracker, nil] a new tracker instance, or nil
+        # @return [AIConfigTracker] a new tracker instance
         #
         def create_tracker
-          @tracker_factory&.call
+          @tracker_factory.call
         end
 
         #

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -123,15 +123,6 @@ module LaunchDarkly
           @tracker_factory.call
         end
 
-        #
-        # Returns a new disabled AIConfig instance.
-        #
-        # @return [AIConfig] a new disabled config
-        #
-        def self.disabled
-          new(enabled: false)
-        end
-
         def to_h
           {
             _ldMeta: {
@@ -149,6 +140,9 @@ module LaunchDarkly
       #
       TRACK_SDK_INFO = '$ld:ai:sdk:info'
       TRACK_USAGE_COMPLETION_CONFIG = '$ld:ai:usage:completion-config'
+
+      # Internal fallback used when no default config is provided. Not part of the public API.
+      DISABLED_AI_CONFIG_DEFAULT = { _ldMeta: { enabled: false } }.freeze
 
       INIT_TRACK_CONTEXT = LaunchDarkly::LDContext.create({
         kind: 'ld_ai',
@@ -189,7 +183,7 @@ module LaunchDarkly
         def completion_config(key:, context:, default: nil, variables: nil)
           @ld_client.track(TRACK_USAGE_COMPLETION_CONFIG, context, key, 1)
 
-          _completion_config(key:, context:, default: default || AIConfig.disabled, variables:)
+          _completion_config(key:, context:, default: default || DISABLED_AI_CONFIG_DEFAULT, variables:)
         end
 
         #

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -451,6 +451,20 @@ RSpec.describe LaunchDarkly::Server::AI do
       end
     end
 
+    describe LaunchDarkly::Server::AI::AIConfig do
+      it 'does not expose a public disabled class method' do
+        expect(described_class).not_to respond_to(:disabled)
+      end
+
+      it 'requires a tracker_factory to construct' do
+        expect { described_class.new(enabled: false) }.to raise_error(ArgumentError, /tracker_factory/)
+      end
+
+      it 'is not a subclass of AIConfigDefault' do
+        expect(described_class.ancestors).not_to include(LaunchDarkly::Server::AI::AIConfigDefault)
+      end
+    end
+
     describe LaunchDarkly::Server::AI::AIConfigDefault do
       it 'defaults to a disabled configuration' do
         config = described_class.new

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -410,9 +410,13 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(flag_data[:providerName]).to eq('fakeProvider')
       end
 
-      it 'create_tracker returns nil for static disabled config' do
-        config = LaunchDarkly::Server::AI::AIConfig.disabled
-        expect(config.create_tracker).to be_nil
+      it 'create_tracker returns a tracker even for disabled configs from evaluation' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'off-config', context:)
+
+        expect(config.enabled).to be false
+        tracker = config.create_tracker
+        expect(tracker).to be_a(LaunchDarkly::Server::AI::AIConfigTracker)
       end
 
       it 'round-trips a tracker through a resumption token via client create_tracker' do

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -461,6 +461,21 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(config.provider).to be_nil
       end
 
+      it 'disabled class method returns a disabled AIConfigDefault' do
+        config = described_class.disabled
+        expect(config).to be_a(described_class)
+        expect(config.enabled).to be false
+        expect(config.messages).to be_nil
+        expect(config.model).to be_nil
+        expect(config.provider).to be_nil
+      end
+
+      it 'disabled class method returns a new instance each call' do
+        first = described_class.disabled
+        second = described_class.disabled
+        expect(first).not_to be(second)
+      end
+
       it 'serializes to a hash matching the variation format' do
         model = LaunchDarkly::Server::AI::ModelConfig.new(name: 'test-model')
         messages = [LaunchDarkly::Server::AI::Message.new('system', 'Hello')]

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe LaunchDarkly::Server::AI do
                                                     temperature: 0.5, maxTokens: 4096
                                                   })
         messages = [LaunchDarkly::Server::AI::Message.new('system', 'Hello, {{name}}!')]
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: model,
           messages: messages
@@ -174,7 +174,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'interpolates variables in model config messages' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fakeModel'),
           messages: [LaunchDarkly::Server::AI::Message.new('system', 'Hello, {{name}}!')]
@@ -195,7 +195,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'returns config with messages interpolated as empty when no variables are provided' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fakeModel'),
           messages: []
@@ -216,7 +216,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'handles provider config correctly' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user', name: 'Sandy' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -237,7 +237,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'interpolates context variables in messages using ldctx' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user', name: 'Sandy', last: 'Beaches' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -263,7 +263,7 @@ RSpec.describe LaunchDarkly::Server::AI do
         org_context = LaunchDarkly::LDContext.create({ key: 'org-key', kind: 'org', name: 'LaunchDarkly',
                                                        shortname: 'LD' })
         context = LaunchDarkly::LDContext.create_multi([user_context, org_context])
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -286,7 +286,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'handles multiple messages and variable interpolation' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -309,7 +309,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'returns disabled config when flag is off' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -326,7 +326,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'returns disabled config with nil model/messages/provider when initial config is disabled' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: true,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -342,7 +342,7 @@ RSpec.describe LaunchDarkly::Server::AI do
 
       it 'returns enabled config with nil model/messages/provider when initial config is enabled' do
         context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        default = LaunchDarkly::Server::AI::AIConfig.new(
+        default = LaunchDarkly::Server::AI::AIConfigDefault.new(
           enabled: false,
           model: LaunchDarkly::Server::AI::ModelConfig.new(name: 'fake-model'),
           messages: []
@@ -451,19 +451,26 @@ RSpec.describe LaunchDarkly::Server::AI do
       end
     end
 
-    describe LaunchDarkly::Server::AI::AIConfig do
-      it 'disabled class method returns a disabled AIConfig' do
-        config = described_class.disabled
+    describe LaunchDarkly::Server::AI::AIConfigDefault do
+      it 'defaults to a disabled configuration' do
+        config = described_class.new
         expect(config).to be_a(described_class)
         expect(config.enabled).to be false
         expect(config.messages).to be_nil
         expect(config.model).to be_nil
+        expect(config.provider).to be_nil
       end
 
-      it 'disabled class method returns a new instance each call' do
-        first = described_class.disabled
-        second = described_class.disabled
-        expect(first).not_to be(second)
+      it 'serializes to a hash matching the variation format' do
+        model = LaunchDarkly::Server::AI::ModelConfig.new(name: 'test-model')
+        messages = [LaunchDarkly::Server::AI::Message.new('system', 'Hello')]
+        config = described_class.new(enabled: true, model: model, messages: messages)
+        hash = config.to_h
+
+        expect(hash[:_ldMeta][:enabled]).to be true
+        expect(hash[:model][:name]).to eq('test-model')
+        expect(hash[:messages].length).to eq(1)
+        expect(hash[:messages][0][:content]).to eq('Hello')
       end
     end
   end

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -227,8 +227,9 @@ RSpec.describe LaunchDarkly::Server::AI do
 
         expect(config.provider).not_to be_nil
         expect(config.provider.name).to eq('fakeProvider')
-        expect(config.tracker).not_to be_nil
-        expect(config.tracker.send(:flag_data)).to include(
+        tracker = config.create_tracker
+        expect(tracker).not_to be_nil
+        expect(tracker.send(:flag_data)).to include(
           modelName: 'fakeModel',
           providerName: 'fakeProvider'
         )
@@ -353,8 +354,9 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(config.model).to be_nil
         expect(config.messages).to be_nil
         expect(config.provider).to be_nil
-        expect(config.tracker).not_to be_nil
-        expect(config.tracker.send(:flag_data)).to include(
+        tracker = config.create_tracker
+        expect(tracker).not_to be_nil
+        expect(tracker.send(:flag_data)).to include(
           modelName: '',
           providerName: ''
         )
@@ -374,6 +376,74 @@ RSpec.describe LaunchDarkly::Server::AI do
         config = ai_client.completion_config(key: 'missing-flag', context:, default: nil)
 
         expect(config.enabled).to be false
+      end
+
+      it 'create_tracker returns a new tracker with a fresh runId each time' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config', context:, variables: { 'name' => 'World' })
+
+        tracker1 = config.create_tracker
+        tracker2 = config.create_tracker
+
+        expect(tracker1).to be_a(LaunchDarkly::Server::AI::AIConfigTracker)
+        expect(tracker2).to be_a(LaunchDarkly::Server::AI::AIConfigTracker)
+        expect(tracker1).not_to equal(tracker2)
+
+        run_id1 = tracker1.send(:flag_data)[:runId]
+        run_id2 = tracker2.send(:flag_data)[:runId]
+        expect(run_id1).not_to eq(run_id2)
+        expect(run_id1).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+        expect(run_id2).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+      end
+
+      it 'create_tracker preserves flag metadata across calls' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config', context:, variables: { 'name' => 'World' })
+
+        tracker = config.create_tracker
+        flag_data = tracker.send(:flag_data)
+
+        expect(flag_data[:configKey]).to eq('model-config')
+        expect(flag_data[:variationKey]).to eq('abcd')
+        expect(flag_data[:version]).to eq(1)
+        expect(flag_data[:modelName]).to eq('fakeModel')
+        expect(flag_data[:providerName]).to eq('fakeProvider')
+      end
+
+      it 'create_tracker returns nil for static disabled config' do
+        config = LaunchDarkly::Server::AI::AIConfig.disabled
+        expect(config.create_tracker).to be_nil
+      end
+
+      it 'round-trips a tracker through a resumption token via client create_tracker' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config', context:, variables: { 'name' => 'World' })
+
+        tracker = config.create_tracker
+        token = tracker.resumption_token
+        original_run_id = tracker.send(:flag_data)[:runId]
+
+        restored = ai_client.create_tracker(token: token, context: context)
+
+        expect(restored).to be_a(LaunchDarkly::Server::AI::AIConfigTracker)
+        expect(restored.send(:flag_data)[:runId]).to eq(original_run_id)
+        expect(restored.send(:flag_data)[:configKey]).to eq('model-config')
+        expect(restored.send(:flag_data)[:modelName]).to eq('')
+        expect(restored.send(:flag_data)[:providerName]).to eq('')
+      end
+
+      it 'each tracker has independent at-most-once tracking' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config', context:, variables: { 'name' => 'World' })
+
+        tracker1 = config.create_tracker
+        tracker2 = config.create_tracker
+
+        tracker1.track_duration(100)
+        tracker2.track_duration(200)
+
+        expect(tracker1.summary.duration).to eq(100)
+        expect(tracker2.summary.duration).to eq(200)
       end
     end
 

--- a/spec/server/ai/config_tracker_spec.rb
+++ b/spec/server/ai/config_tracker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
   end
 
   let(:context) { LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' }) }
-  let(:tracker_flag_data) { { variationKey: 'test-variation', configKey: 'test-config', version: 1, modelName: 'fakeModel', providerName: 'fakeProvider' } }
+  let(:tracker_flag_data) { { runId: kind_of(String), variationKey: 'test-variation', configKey: 'test-config', version: 1, modelName: 'fakeModel', providerName: 'fakeProvider' } }
   let(:tracker) do
     described_class.new(
       ld_client: ld_client,
@@ -322,15 +322,9 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
       expect(tracker.summary.success).to be false
     end
 
-    it 'overwrites success with error if both are tracked' do
+    it 'does not track error if success has already been tracked' do
       expect(ld_client).to receive(:track).with(
         '$ld:ai:generation:success',
-        context,
-        tracker_flag_data,
-        1
-      )
-      expect(ld_client).to receive(:track).with(
-        '$ld:ai:generation:error',
         context,
         tracker_flag_data,
         1
@@ -339,7 +333,95 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
       tracker.track_success
       expect(tracker.summary.success).to be true
       tracker.track_error
+      expect(tracker.summary.success).to be true
+    end
+  end
+
+  describe 'at-most-once tracking' do
+    it 'only tracks duration once' do
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:duration:total',
+        context,
+        tracker_flag_data,
+        100
+      ).once
+      tracker.track_duration(100)
+      tracker.track_duration(200)
+      expect(tracker.summary.duration).to eq(100)
+    end
+
+    it 'only tracks time to first token once' do
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:tokens:ttf',
+        context,
+        tracker_flag_data,
+        100
+      ).once
+      tracker.track_time_to_first_token(100)
+      tracker.track_time_to_first_token(200)
+      expect(tracker.summary.time_to_first_token).to eq(100)
+    end
+
+    it 'only tracks tokens once' do
+      tokens1 = LaunchDarkly::Server::AI::TokenUsage.new(total: 300, input: 200, output: 100)
+      tokens2 = LaunchDarkly::Server::AI::TokenUsage.new(total: 600, input: 400, output: 200)
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:tokens:total',
+        context,
+        tracker_flag_data,
+        300
+      ).once
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:tokens:input',
+        context,
+        tracker_flag_data,
+        200
+      ).once
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:tokens:output',
+        context,
+        tracker_flag_data,
+        100
+      ).once
+      tracker.track_tokens(tokens1)
+      tracker.track_tokens(tokens2)
+      expect(tracker.summary.usage).to eq(tokens1)
+    end
+
+    it 'only tracks success once' do
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:generation:success',
+        context,
+        tracker_flag_data,
+        1
+      ).once
+      tracker.track_success
+      tracker.track_success
+      expect(tracker.summary.success).to be true
+    end
+
+    it 'only tracks error once' do
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:generation:error',
+        context,
+        tracker_flag_data,
+        1
+      ).once
+      tracker.track_error
+      tracker.track_error
       expect(tracker.summary.success).to be false
+    end
+
+    it 'only tracks feedback once' do
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:feedback:user:positive',
+        context,
+        tracker_flag_data,
+        1
+      ).once
+      tracker.track_feedback(kind: :positive)
+      tracker.track_feedback(kind: :negative)
+      expect(tracker.summary.feedback).to eq(:positive)
     end
   end
 
@@ -370,11 +452,14 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
   end
 
   describe '#flag_data' do
-    it 'includes model_name and provider_name in flag data' do
-      expect(tracker.send(:flag_data)).to include(
+    it 'includes runId, model_name, and provider_name in flag data' do
+      flag_data = tracker.send(:flag_data)
+      expect(flag_data).to include(
+        runId: kind_of(String),
         modelName: 'fakeModel',
         providerName: 'fakeProvider'
       )
+      expect(flag_data[:runId]).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
     end
   end
 

--- a/spec/server/ai/config_tracker_spec.rb
+++ b/spec/server/ai/config_tracker_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'base64'
+require 'json'
+require 'securerandom'
 require 'launchdarkly-server-sdk'
 require 'launchdarkly-server-sdk-ai'
 
@@ -31,6 +34,7 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
   let(:tracker) do
     described_class.new(
       ld_client: ld_client,
+      run_id: SecureRandom.uuid,
       config_key: tracker_flag_data[:configKey],
       context: context,
       variation_key: tracker_flag_data[:variationKey],
@@ -460,6 +464,94 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
         providerName: 'fakeProvider'
       )
       expect(flag_data[:runId]).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+    end
+  end
+
+  describe '#resumption_token' do
+    it 'returns a URL-safe base64-encoded JSON string' do
+      token = tracker.resumption_token
+      decoded = JSON.parse(Base64.urlsafe_decode64(token))
+
+      expect(decoded['runId']).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+      expect(decoded['configKey']).to eq('test-config')
+      expect(decoded['variationKey']).to eq('test-variation')
+      expect(decoded['version']).to eq(1)
+    end
+
+    it 'does not include modelName or providerName' do
+      token = tracker.resumption_token
+      decoded = JSON.parse(Base64.urlsafe_decode64(token))
+
+      expect(decoded).not_to have_key('modelName')
+      expect(decoded).not_to have_key('providerName')
+    end
+
+    it 'contains the same runId as the tracker flag data' do
+      flag_data = tracker.send(:flag_data)
+      token = tracker.resumption_token
+      decoded = JSON.parse(Base64.urlsafe_decode64(token))
+
+      expect(decoded['runId']).to eq(flag_data[:runId])
+    end
+  end
+
+  describe '.from_resumption_token' do
+    it 'reconstructs a tracker that uses the same runId' do
+      original_token = tracker.resumption_token
+      original_run_id = tracker.send(:flag_data)[:runId]
+
+      restored = described_class.from_resumption_token(
+        token: original_token,
+        ld_client: ld_client,
+        context: context
+      )
+
+      expect(restored.send(:flag_data)[:runId]).to eq(original_run_id)
+      expect(restored.send(:flag_data)[:configKey]).to eq('test-config')
+      expect(restored.send(:flag_data)[:variationKey]).to eq('test-variation')
+      expect(restored.send(:flag_data)[:version]).to eq(1)
+    end
+
+    it 'sets modelName and providerName to empty strings' do
+      token = tracker.resumption_token
+
+      restored = described_class.from_resumption_token(
+        token: token,
+        ld_client: ld_client,
+        context: context
+      )
+
+      expect(restored.send(:flag_data)[:modelName]).to eq('')
+      expect(restored.send(:flag_data)[:providerName]).to eq('')
+    end
+
+    it 'can track events with the restored tracker' do
+      token = tracker.resumption_token
+      original_run_id = tracker.send(:flag_data)[:runId]
+
+      restored = described_class.from_resumption_token(
+        token: token,
+        ld_client: ld_client,
+        context: context
+      )
+
+      expected_data = {
+        runId: original_run_id,
+        variationKey: 'test-variation',
+        configKey: 'test-config',
+        version: 1,
+        modelName: '',
+        providerName: '',
+      }
+
+      expect(ld_client).to receive(:track).with(
+        '$ld:ai:feedback:user:positive',
+        context,
+        expected_data,
+        1
+      )
+
+      restored.track_feedback(kind: :positive)
     end
   end
 

--- a/spec/server/ai/config_tracker_spec.rb
+++ b/spec/server/ai/config_tracker_spec.rb
@@ -553,6 +553,27 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
 
       restored.track_feedback(kind: :positive)
     end
+
+    it 'round-trips an empty variation_key as an empty string' do
+      empty_tracker = described_class.new(
+        ld_client: ld_client,
+        run_id: SecureRandom.uuid,
+        config_key: 'test-config',
+        context: context,
+        variation_key: '',
+        version: 1,
+        model_name: 'fakeModel',
+        provider_name: 'fakeProvider'
+      )
+
+      restored = described_class.from_resumption_token(
+        token: empty_tracker.resumption_token,
+        ld_client: ld_client,
+        context: context
+      )
+
+      expect(restored.variation_key).to eq('')
+    end
   end
 
   describe 'completion_config method tracking' do


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat!: Add per-execution runId, at-most-once tracking, and cross-process tracker resumption
feat!: Replace tracker tuple from completion_config with AIConfig#create_tracker factory
feat!: Track each AIConfigTracker metric at most once per tracker
feat: Add per-execution runId to correlate AIConfigTracker events
feat: Add Client#create_tracker(token:, context:) to resume a tracker across processes
END_COMMIT_OVERRIDE

## Summary

- **Per-execution `runId`**: Every tracker event now includes a unique `runId` (UUID v4) for billing isolation and deduplication
- **At-most-once semantics**: Each metric type (duration, tokens, success/error, feedback, TTFT) can only be tracked once per tracker instance; subsequent calls are dropped with a warning
- **`AIConfig#create_tracker` factory**: The completion config object returned by `Client#completion_config` exposes a `create_tracker` method that returns a fresh `AIConfigTracker` with a new `runId` on each call, replacing the old single-tracker pattern. The SDK always supplies a working tracker factory, even for disabled flag evaluations.
- **`AIConfigDefault` / `AIConfig` are independent classes**: `AIConfigDefault` is the application-supplied fallback type (passed as `default:` to `Client#completion_config`); `AIConfig` is the SDK-returned type that carries a tracker factory. Direct construction of `AIConfig` is not supported.
- **Resumption token**: `AIConfigTracker#resumption_token` returns a URL-safe Base64-encoded JSON token (`{ runId, configKey, variationKey, version }`) for cross-process tracker reconstruction
- **`Client#create_tracker(token:, context:)`**: Reconstructs a tracker from a resumption token for deferred tracking (e.g. feedback from a different process). `modelName` and `providerName` are set to empty strings on reconstruction.
- **`base64` gem dependency**: Added as a runtime dependency (removed from Ruby 3.4 default gems)

## Test plan

- [x] `AIConfig#create_tracker` returns new tracker instances with distinct `runId`s
- [x] `AIConfig#create_tracker` preserves flag metadata (configKey, variationKey, version, modelName, providerName)
- [x] `AIConfigDefault.disabled` returns a disabled fallback config
- [x] `AIConfig` is not a subclass of `AIConfigDefault` and does not expose a `disabled` class method
- [x] `AIConfig.new` requires a `tracker_factory:` keyword argument
- [x] Trackers from the same config have independent at-most-once tracking state
- [x] `resumption_token` encodes exactly `{ runId, configKey, variationKey, version }` (no modelName/providerName)
- [x] `from_resumption_token` round-trips correctly and sets modelName/providerName to `""`
- [x] Restored tracker can send track events with the original `runId`
- [x] `Client#create_tracker` round-trips through resumption token
- [x] All 57 tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the public tracking API (`AIConfig`/default handling) and modifies emitted analytics event payloads by introducing per-run `runId` and at-most-once semantics, which could affect downstream metrics/billing expectations.
> 
> **Overview**
> Introduces per-execution tracking by minting a UUIDv4 `runId` for each AI run and attaching it to all tracker events, with a new `AIConfig#create_tracker` factory replacing the previous single-tracker pattern.
> 
> Adds at-most-once semantics to `AIConfigTracker` metric methods (duration, TTFT, tokens, success/error, feedback), dropping subsequent calls with warnings, and implements cross-process tracker resumption via `AIConfigTracker#resumption_token` plus `Client#create_tracker(token:, context:)`.
> 
> Splits fallback vs returned config types by adding `AIConfigDefault` for `completion_config(default:)`, removes `AIConfig.disabled`, updates examples/tests accordingly, and adds a runtime `base64` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bcf1f1f7c8f1935ea8ebacc53d29e3e5f4dbe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


