### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality — N/A (CI workflow change only)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions — N/A (CI workflow change only)

**Related issues**

- Root cause: [launchdarkly/gh-actions#86](https://github.com/launchdarkly/gh-actions/pull/86) added `permissions: pull-requests: read` at the job level inside the reusable `lint-pr-title` workflow
- Same fix as [launchdarkly/sdk-meta#429](https://github.com/launchdarkly/sdk-meta/pull/429)

**Describe the solution you've provided**

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

A reusable workflow can only request a subset of the permissions the caller has granted. Since this caller had no `permissions` block, the reusable workflow's `pull-requests: read` request could not be satisfied, causing every run to hit `startup_failure`.

**Describe alternatives you've considered**

Reverting the permission declaration in the reusable workflow itself, but that would remove a security improvement (least-privilege scoping) across all consumers.

**Additional context**

No product code is changed. The `Lint PR title` check on this PR itself should exit `success` rather than `startup_failure`, confirming the fix.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that expands workflow permissions to `pull-requests: read` so the reusable `lint-pr-title` workflow can run; no product code or data paths are affected.
> 
> **Overview**
> Fixes the `Lint PR title` GitHub Actions workflow startup failure by explicitly granting **workflow-level** `permissions: pull-requests: read`, allowing the called reusable `lint-pr-title` workflow to request and use PR read access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c25bf4d2f4be9e93b0fad0cecd875916f55a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->