### PR TITLE
feat(server-ai): stamp modelKey and modelVersion on AI usage events (AIC-2857)

### DIFF
--- a/lib/server/ai/ai_config_tracker.rb
+++ b/lib/server/ai/ai_config_tracker.rb
@@ -51,7 +51,8 @@ module LaunchDarkly
       # tracker reconstructed in another process share the original runId.
       #
       class AIConfigTracker
-        attr_reader :ld_client, :config_key, :context, :variation_key, :version, :summary, :model_name, :provider_name
+        attr_reader :ld_client, :config_key, :context, :variation_key, :version, :summary, :model_name, :provider_name,
+                    :model_key, :model_version
 
         #
         # Initialize a new AIConfigTracker instance.
@@ -62,15 +63,20 @@ module LaunchDarkly
         # @param version [Integer] The version number
         # @param model_name [String] The name of the AI model being used
         # @param provider_name [String] The name of the AI provider
+        # @param model_key [String, nil] The stable, unique key of the model used
+        # @param model_version [Integer] The pinned version of the model used
         # @param context [LDContext] The context used for the flag evaluation
         #
-        def initialize(ld_client:, run_id:, config_key:, variation_key:, version:, context:, model_name:, provider_name:)
+        def initialize(ld_client:, run_id:, config_key:, variation_key:, version:, context:, model_name:, provider_name:,
+                       model_key: nil, model_version: 1)
           @ld_client = ld_client
           @variation_key = variation_key
           @config_key = config_key
           @version = version
           @model_name = model_name
           @provider_name = provider_name
+          @model_key = model_key
+          @model_version = model_version
           @context = context
           @summary = MetricSummary.new
           @run_id = run_id
@@ -82,7 +88,7 @@ module LaunchDarkly
         # a tracker in a different process (e.g. for deferred feedback).
         #
         # The token contains: runId, configKey, variationKey, version.
-        # modelName and providerName are NOT included.
+        # modelName, providerName, modelKey, and modelVersion are NOT included.
         #
         # @return [String] the resumption token
         #
@@ -328,8 +334,10 @@ module LaunchDarkly
             version: @version,
             modelName: @model_name,
             providerName: @provider_name,
+            modelVersion: @model_version,
           }
           data[:variationKey] = @variation_key if @variation_key && !@variation_key.empty?
+          data[:modelKey] = @model_key if @model_key && !@model_key.empty?
           data
         end
 

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -38,12 +38,14 @@ module LaunchDarkly
       # The ModelConfig class represents an AI model configuration.
       #
       class ModelConfig
-        attr_reader :name
+        attr_reader :name, :model_key, :model_version
 
-        def initialize(name:, parameters: {}, custom: {})
+        def initialize(name:, parameters: {}, custom: {}, model_key: nil, model_version: nil)
           @name = name
           @parameters = parameters
           @custom = custom
+          @model_key = model_key
+          @model_version = model_version
         end
 
         #
@@ -75,11 +77,14 @@ module LaunchDarkly
         end
 
         def to_h
-          {
+          result = {
             name: @name,
             parameters: @parameters,
             custom: @custom,
           }
+          result[:modelKey] = @model_key if @model_key && !@model_key.empty?
+          result[:modelVersion] = @model_version unless @model_version.nil?
+          result
         end
       end
 
@@ -280,13 +285,17 @@ module LaunchDarkly
             provider_config = ProviderConfig.new(provider_config.fetch(:name, ''))
           end
 
+          tracked_model_version = 1
           if (model = variation[:model]) && model.is_a?(Hash)
             parameters = variation[:model][:parameters]
             custom = variation[:model][:custom]
+            tracked_model_version = (variation[:model][:modelVersion] || 1).to_i
             model = ModelConfig.new(
               name: variation[:model][:name],
               parameters: parameters,
-              custom: custom
+              custom: custom,
+              model_key: variation[:model][:modelKey],
+              model_version: tracked_model_version
             )
           end
 
@@ -294,6 +303,7 @@ module LaunchDarkly
           version = variation.dig(:_ldMeta, :version) || 1
           model_name = model&.name || ''
           provider_name = provider_config&.name || ''
+          model_key = model&.model_key
 
           tracker_factory = lambda {
             LaunchDarkly::Server::AI::AIConfigTracker.new(
@@ -304,6 +314,8 @@ module LaunchDarkly
               version: version,
               model_name: model_name,
               provider_name: provider_name,
+              model_key: model_key,
+              model_version: tracked_model_version,
               context: context
             )
           }

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -285,16 +285,15 @@ module LaunchDarkly
             provider_config = ProviderConfig.new(provider_config.fetch(:name, ''))
           end
 
-          tracked_model_version = 1
+          tracked_model_version = (variation.dig(:_ldMeta, :modelVersion) || 1).to_i
           if (model = variation[:model]) && model.is_a?(Hash)
             parameters = variation[:model][:parameters]
             custom = variation[:model][:custom]
-            tracked_model_version = (variation[:model][:modelVersion] || 1).to_i
             model = ModelConfig.new(
               name: variation[:model][:name],
               parameters: parameters,
               custom: custom,
-              model_key: variation[:model][:modelKey],
+              model_key: variation.dig(:_ldMeta, :modelKey),
               model_version: tracked_model_version
             )
           end

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -38,14 +38,12 @@ module LaunchDarkly
       # The ModelConfig class represents an AI model configuration.
       #
       class ModelConfig
-        attr_reader :name, :model_key, :model_version
+        attr_reader :name
 
-        def initialize(name:, parameters: {}, custom: {}, model_key: nil, model_version: nil)
+        def initialize(name:, parameters: {}, custom: {})
           @name = name
           @parameters = parameters
           @custom = custom
-          @model_key = model_key
-          @model_version = model_version
         end
 
         #
@@ -77,14 +75,11 @@ module LaunchDarkly
         end
 
         def to_h
-          result = {
+          {
             name: @name,
             parameters: @parameters,
             custom: @custom,
           }
-          result[:modelKey] = @model_key if @model_key && !@model_key.empty?
-          result[:modelVersion] = @model_version unless @model_version.nil?
-          result
         end
       end
 
@@ -292,9 +287,7 @@ module LaunchDarkly
             model = ModelConfig.new(
               name: variation[:model][:name],
               parameters: parameters,
-              custom: custom,
-              model_key: variation.dig(:_ldMeta, :modelKey),
-              model_version: tracked_model_version
+              custom: custom
             )
           end
 
@@ -302,7 +295,7 @@ module LaunchDarkly
           version = variation.dig(:_ldMeta, :version) || 1
           model_name = model&.name || ''
           provider_name = provider_config&.name || ''
-          model_key = model&.model_key
+          model_key = variation.dig(:_ldMeta, :modelKey)
 
           tracker_factory = lambda {
             LaunchDarkly::Server::AI::AIConfigTracker.new(

--- a/lib/server/ai/client.rb
+++ b/lib/server/ai/client.rb
@@ -280,7 +280,6 @@ module LaunchDarkly
             provider_config = ProviderConfig.new(provider_config.fetch(:name, ''))
           end
 
-          tracked_model_version = (variation.dig(:_ldMeta, :modelVersion) || 1).to_i
           if (model = variation[:model]) && model.is_a?(Hash)
             parameters = variation[:model][:parameters]
             custom = variation[:model][:custom]
@@ -296,6 +295,7 @@ module LaunchDarkly
           model_name = model&.name || ''
           provider_name = provider_config&.name || ''
           model_key = variation.dig(:_ldMeta, :modelKey)
+          model_version = (variation.dig(:_ldMeta, :modelVersion) || 1).to_i
 
           tracker_factory = lambda {
             LaunchDarkly::Server::AI::AIConfigTracker.new(
@@ -307,7 +307,7 @@ module LaunchDarkly
               model_name: model_name,
               provider_name: provider_name,
               model_key: model_key,
-              model_version: tracked_model_version,
+              model_version: model_version,
               context: context
             )
           }

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -93,12 +93,10 @@ RSpec.describe LaunchDarkly::Server::AI do
         {
           model: {
             name: 'gpt-4',
-            modelKey: 'my-model',
-            modelVersion: 2,
           },
           provider: { name: 'openai' },
           messages: [],
-          _ldMeta: { enabled: true, variationKey: 'v1', version: 1 },
+          _ldMeta: { enabled: true, variationKey: 'v1', version: 1, modelKey: 'my-model', modelVersion: 2 },
         }
       )
       .variation_for_all(0))
@@ -487,10 +485,10 @@ RSpec.describe LaunchDarkly::Server::AI do
         td.update(td.flag('model-config-version-only')
           .variations(
             {
-              model: { name: 'gpt-4', modelVersion: 3 },
+              model: { name: 'gpt-4' },
               provider: { name: 'openai' },
               messages: [],
-              _ldMeta: { enabled: true, variationKey: 'v1', version: 1 },
+              _ldMeta: { enabled: true, variationKey: 'v1', version: 1, modelVersion: 3 },
             }
           )
           .variation_for_all(0))

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe LaunchDarkly::Server::AI do
         )
         .variation_for_all(1))
 
+    data_source.update(data_source.flag('model-config-with-key-version')
+      .variations(
+        {
+          model: {
+            name: 'gpt-4',
+            modelKey: 'my-model',
+            modelVersion: 2,
+          },
+          provider: { name: 'openai' },
+          messages: [],
+          _ldMeta: { enabled: true, variationKey: 'v1', version: 1 },
+        }
+      )
+      .variation_for_all(0))
+
     data_source
   end
 
@@ -112,6 +127,28 @@ RSpec.describe LaunchDarkly::Server::AI do
       expect(model.custom(:'extra-attribute')).to eq('value')
       expect(model.custom('non-existent')).to be_nil
       expect(model.custom('name')).to be_nil
+    end
+
+    it 'to_h omits modelKey and modelVersion when unset' do
+      model = described_class.new(name: 'fakeModel', parameters: { temperature: 0.5 })
+      expect(model.model_key).to be_nil
+      expect(model.model_version).to be_nil
+      result = model.to_h
+      expect(result).not_to have_key(:modelKey)
+      expect(result).not_to have_key(:modelVersion)
+    end
+
+    it 'to_h includes modelKey and modelVersion when set' do
+      model = described_class.new(name: 'fakeModel', model_key: 'my-model', model_version: 2)
+      result = model.to_h
+      expect(result[:modelKey]).to eq('my-model')
+      expect(result[:modelVersion]).to eq(2)
+    end
+
+    it 'to_h omits empty modelKey' do
+      model = described_class.new(name: 'fakeModel', model_key: '')
+      result = model.to_h
+      expect(result).not_to have_key(:modelKey)
     end
   end
 
@@ -408,6 +445,64 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(flag_data[:version]).to eq(1)
         expect(flag_data[:modelName]).to eq('fakeModel')
         expect(flag_data[:providerName]).to eq('fakeProvider')
+        expect(flag_data[:modelVersion]).to eq(1)
+        expect(flag_data).not_to have_key(:modelKey)
+      end
+
+      it 'reads modelKey and modelVersion from flag payload' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config-with-key-version', context:)
+
+        expect(config.model).not_to be_nil
+        expect(config.model.model_key).to eq('my-model')
+        expect(config.model.model_version).to eq(2)
+      end
+
+      it 'stamps modelKey and modelVersion on track data' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config-with-key-version', context:)
+
+        tracker = config.create_tracker
+        expect(ld_client).to receive(:track).with(
+          '$ld:ai:generation:success',
+          context,
+          hash_including(modelKey: 'my-model', modelVersion: 2),
+          1
+        )
+        tracker.track_success
+      end
+
+      it 'defaults modelVersion to 1 and omits modelKey when absent from payload' do
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config', context:, variables: { 'name' => 'World' })
+
+        tracker = config.create_tracker
+        flag_data = tracker.send(:flag_data)
+
+        expect(flag_data[:modelVersion]).to eq(1)
+        expect(flag_data).not_to have_key(:modelKey)
+      end
+
+      it 'uses explicit modelVersion from payload when modelKey is absent' do
+        td.update(td.flag('model-config-version-only')
+          .variations(
+            {
+              model: { name: 'gpt-4', modelVersion: 3 },
+              provider: { name: 'openai' },
+              messages: [],
+              _ldMeta: { enabled: true, variationKey: 'v1', version: 1 },
+            }
+          )
+          .variation_for_all(0))
+
+        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
+        config = ai_client.completion_config(key: 'model-config-version-only', context:)
+
+        tracker = config.create_tracker
+        flag_data = tracker.send(:flag_data)
+
+        expect(flag_data[:modelVersion]).to eq(3)
+        expect(flag_data).not_to have_key(:modelKey)
       end
 
       it 'create_tracker returns a tracker even for disabled configs from evaluation' do
@@ -434,6 +529,8 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(restored.send(:flag_data)[:configKey]).to eq('model-config')
         expect(restored.send(:flag_data)[:modelName]).to eq('')
         expect(restored.send(:flag_data)[:providerName]).to eq('')
+        expect(restored.send(:flag_data)[:modelVersion]).to eq(1)
+        expect(restored.send(:flag_data)).not_to have_key(:modelKey)
       end
 
       it 'each tracker has independent at-most-once tracking' do

--- a/spec/server/ai/client_spec.rb
+++ b/spec/server/ai/client_spec.rb
@@ -127,27 +127,6 @@ RSpec.describe LaunchDarkly::Server::AI do
       expect(model.custom('name')).to be_nil
     end
 
-    it 'to_h omits modelKey and modelVersion when unset' do
-      model = described_class.new(name: 'fakeModel', parameters: { temperature: 0.5 })
-      expect(model.model_key).to be_nil
-      expect(model.model_version).to be_nil
-      result = model.to_h
-      expect(result).not_to have_key(:modelKey)
-      expect(result).not_to have_key(:modelVersion)
-    end
-
-    it 'to_h includes modelKey and modelVersion when set' do
-      model = described_class.new(name: 'fakeModel', model_key: 'my-model', model_version: 2)
-      result = model.to_h
-      expect(result[:modelKey]).to eq('my-model')
-      expect(result[:modelVersion]).to eq(2)
-    end
-
-    it 'to_h omits empty modelKey' do
-      model = described_class.new(name: 'fakeModel', model_key: '')
-      result = model.to_h
-      expect(result).not_to have_key(:modelKey)
-    end
   end
 
   describe LaunchDarkly::Server::AI::Client do
@@ -445,15 +424,6 @@ RSpec.describe LaunchDarkly::Server::AI do
         expect(flag_data[:providerName]).to eq('fakeProvider')
         expect(flag_data[:modelVersion]).to eq(1)
         expect(flag_data).not_to have_key(:modelKey)
-      end
-
-      it 'reads modelKey and modelVersion from flag payload' do
-        context = LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' })
-        config = ai_client.completion_config(key: 'model-config-with-key-version', context:)
-
-        expect(config.model).not_to be_nil
-        expect(config.model.model_key).to eq('my-model')
-        expect(config.model.model_version).to eq(2)
       end
 
       it 'stamps modelKey and modelVersion on track data' do

--- a/spec/server/ai/config_tracker_spec.rb
+++ b/spec/server/ai/config_tracker_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
   end
 
   let(:context) { LaunchDarkly::LDContext.create({ key: 'user-key', kind: 'user' }) }
-  let(:tracker_flag_data) { { runId: kind_of(String), variationKey: 'test-variation', configKey: 'test-config', version: 1, modelName: 'fakeModel', providerName: 'fakeProvider' } }
+  let(:tracker_flag_data) {
+ { runId: kind_of(String), variationKey: 'test-variation', configKey: 'test-config', version: 1, modelName: 'fakeModel', providerName: 'fakeProvider', modelVersion: 1 } }
   let(:tracker) do
     described_class.new(
       ld_client: ld_client,
@@ -461,9 +462,48 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
       expect(flag_data).to include(
         runId: kind_of(String),
         modelName: 'fakeModel',
-        providerName: 'fakeProvider'
+        providerName: 'fakeProvider',
+        modelVersion: 1
       )
       expect(flag_data[:runId]).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+    end
+
+    it 'includes modelKey when set' do
+      tracker_with_key = described_class.new(
+        ld_client: ld_client,
+        run_id: SecureRandom.uuid,
+        config_key: 'test-config',
+        context: context,
+        variation_key: 'test-variation',
+        version: 1,
+        model_name: 'fakeModel',
+        provider_name: 'fakeProvider',
+        model_key: 'my-model',
+        model_version: 2
+      )
+
+      flag_data = tracker_with_key.send(:flag_data)
+      expect(flag_data[:modelKey]).to eq('my-model')
+      expect(flag_data[:modelVersion]).to eq(2)
+    end
+
+    it 'omits modelKey when empty' do
+      tracker_with_empty_key = described_class.new(
+        ld_client: ld_client,
+        run_id: SecureRandom.uuid,
+        config_key: 'test-config',
+        context: context,
+        variation_key: 'test-variation',
+        version: 1,
+        model_name: 'fakeModel',
+        provider_name: 'fakeProvider',
+        model_key: '',
+        model_version: 3
+      )
+
+      flag_data = tracker_with_empty_key.send(:flag_data)
+      expect(flag_data).not_to have_key(:modelKey)
+      expect(flag_data[:modelVersion]).to eq(3)
     end
   end
 
@@ -478,12 +518,14 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
       expect(decoded['version']).to eq(1)
     end
 
-    it 'does not include modelName or providerName' do
+    it 'does not include modelName, providerName, modelKey, or modelVersion' do
       token = tracker.resumption_token
       decoded = JSON.parse(Base64.urlsafe_decode64(token))
 
       expect(decoded).not_to have_key('modelName')
       expect(decoded).not_to have_key('providerName')
+      expect(decoded).not_to have_key('modelKey')
+      expect(decoded).not_to have_key('modelVersion')
     end
 
     it 'contains the same runId as the tracker flag data' do
@@ -512,7 +554,7 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
       expect(restored.send(:flag_data)[:version]).to eq(1)
     end
 
-    it 'sets modelName and providerName to empty strings' do
+    it 'sets modelName and providerName to empty strings and modelVersion to 1' do
       token = tracker.resumption_token
 
       restored = described_class.from_resumption_token(
@@ -523,6 +565,8 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
 
       expect(restored.send(:flag_data)[:modelName]).to eq('')
       expect(restored.send(:flag_data)[:providerName]).to eq('')
+      expect(restored.send(:flag_data)[:modelVersion]).to eq(1)
+      expect(restored.send(:flag_data)).not_to have_key(:modelKey)
     end
 
     it 'can track events with the restored tracker' do
@@ -542,6 +586,7 @@ RSpec.describe LaunchDarkly::Server::AI::AIConfigTracker do
         version: 1,
         modelName: '',
         providerName: '',
+        modelVersion: 1,
       }
 
       expect(ld_client).to receive(:track).with(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Read `modelKey` and `modelVersion` from the AI Config variation payload (`variation['model']`) and expose them on `ModelConfig`
- Stamp `modelKey` (when present) and `modelVersion` on all `AIConfigTracker` metric event payloads, alongside existing `modelName`/`providerName` fields
- Default `modelVersion` to `1` when absent, matching variation version handling; exclude both fields from the resumption token
- Additive/backward compatible — older payloads without the new fields continue to work

Part of [AIC-2857](https://launchdarkly.atlassian.net/browse/AIC-2857) / [AIC-2849](https://launchdarkly.atlassian.net/browse/AIC-2849). Mirrors the Python SDK implementation in [python-server-sdk-ai#208](https://github.com/launchdarkly/python-server-sdk-ai/pull/208). Depends on backend payload work ([AIC-2876](https://launchdarkly.atlassian.net/browse/AIC-2876)) shipping `modelKey`/`modelVersion` on variations.

## Test plan

- [x] `bundle exec rspec` (72 passed)
- [x] `bundle exec rubocop` on changed files (no offenses)
- [ ] Verify against a staging environment once AIC-2876 payload is available
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94c75e39-b994-47a2-a2f8-59af0649aaa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94c75e39-b994-47a2-a2f8-59af0649aaa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[AIC-2857]: https://launchdarkly.atlassian.net/browse/AIC-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIC-2849]: https://launchdarkly.atlassian.net/browse/AIC-2849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIC-2876]: https://launchdarkly.atlassian.net/browse/AIC-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/ruby-server-sdk-ai/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->